### PR TITLE
[feature/#10] 특정 가게의 미션 목록 조회 API

### DIFF
--- a/src/main/java/com/umc/workbook_zero/controller/MissionController.java
+++ b/src/main/java/com/umc/workbook_zero/controller/MissionController.java
@@ -4,6 +4,7 @@ import com.umc.workbook_zero.apiPayload.ApiResponse;
 import com.umc.workbook_zero.dto.request.ChallengeMissionRequest;
 import com.umc.workbook_zero.dto.response.ChallengeMissionResponse;
 import com.umc.workbook_zero.dto.response.ChallengingMissionResponse;
+import com.umc.workbook_zero.dto.response.StoreMissionResponse;
 import com.umc.workbook_zero.service.MissionService.MissionCommandService;
 import com.umc.workbook_zero.service.MissionService.MissionQueryService;
 import com.umc.workbook_zero.validation.annotation.ValidPage;
@@ -40,6 +41,16 @@ public class MissionController {
             @ValidPage Integer page
     ) {
         List<ChallengingMissionResponse> responses = missionQueryService.getMyChallengingMissions(memberId, page);
+        return ApiResponse.onSuccess(responses);
+    }
+
+    @GetMapping("/{storeId}")
+    @Operation(summary = "특정 가게의 미션 목록 조회 API", description = "특정한 한 가게의 미션 목록을 조회합니다.")
+    public ApiResponse<List<StoreMissionResponse>> getMissionsByStore(
+            @PathVariable Long storeId,
+            @ValidPage Integer page
+    ) {
+        List<StoreMissionResponse> responses = missionQueryService.getMissionsByStoreId(storeId, page);
         return ApiResponse.onSuccess(responses);
     }
 }

--- a/src/main/java/com/umc/workbook_zero/converter/MissionConverter.java
+++ b/src/main/java/com/umc/workbook_zero/converter/MissionConverter.java
@@ -8,6 +8,7 @@ import com.umc.workbook_zero.domain.mapping.MemberMission;
 import com.umc.workbook_zero.dto.request.AddMissionRequest;
 import com.umc.workbook_zero.dto.response.ChallengeMissionResponse;
 import com.umc.workbook_zero.dto.response.ChallengingMissionResponse;
+import com.umc.workbook_zero.dto.response.StoreMissionResponse;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -49,6 +50,17 @@ public class MissionConverter {
                         .missionSpec(m.getMissionSpec())
                         .reward(m.getReward())
                         .deadline(m.getDeadline())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    public List<StoreMissionResponse> toStoreMissionResponseList(List<Mission> missions) {
+        return missions.stream()
+                .map(mission -> StoreMissionResponse.builder()
+                        .missionId(mission.getMissionId())
+                        .reward(mission.getReward())
+                        .deadline(mission.getDeadline())
+                        .missionSpec(mission.getMissionSpec())
                         .build())
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/umc/workbook_zero/dto/response/StoreMissionResponse.java
+++ b/src/main/java/com/umc/workbook_zero/dto/response/StoreMissionResponse.java
@@ -1,0 +1,16 @@
+package com.umc.workbook_zero.dto.response;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StoreMissionResponse {
+    private Long missionId;
+    private Integer reward;
+    private LocalDate deadline;
+    private String missionSpec;
+}

--- a/src/main/java/com/umc/workbook_zero/repository/MissionRepository/MissionRepository.java
+++ b/src/main/java/com/umc/workbook_zero/repository/MissionRepository/MissionRepository.java
@@ -1,7 +1,11 @@
 package com.umc.workbook_zero.repository.MissionRepository;
 
 import com.umc.workbook_zero.domain.Mission;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MissionRepository extends JpaRepository<Mission, Long>, MissionRepositoryCustom {}
+public interface MissionRepository extends JpaRepository<Mission, Long>, MissionRepositoryCustom {
+    Page<Mission> findByStore_StoreId(Long storeId, Pageable pageable);
+}
 

--- a/src/main/java/com/umc/workbook_zero/service/MissionService/MissionQueryService.java
+++ b/src/main/java/com/umc/workbook_zero/service/MissionService/MissionQueryService.java
@@ -1,9 +1,12 @@
 package com.umc.workbook_zero.service.MissionService;
 
 import com.umc.workbook_zero.dto.response.ChallengingMissionResponse;
+import com.umc.workbook_zero.dto.response.StoreMissionResponse;
 
 import java.util.List;
 
 public interface MissionQueryService {
     List<ChallengingMissionResponse> getMyChallengingMissions(Long memberId, int page);
+    List<StoreMissionResponse> getMissionsByStoreId(Long storeId, int page);
+
 }

--- a/src/main/java/com/umc/workbook_zero/service/MissionService/MissionQueryServiceImpl.java
+++ b/src/main/java/com/umc/workbook_zero/service/MissionService/MissionQueryServiceImpl.java
@@ -3,6 +3,7 @@ package com.umc.workbook_zero.service.MissionService;
 import com.umc.workbook_zero.converter.MissionConverter;
 import com.umc.workbook_zero.domain.Mission;
 import com.umc.workbook_zero.dto.response.ChallengingMissionResponse;
+import com.umc.workbook_zero.dto.response.StoreMissionResponse;
 import com.umc.workbook_zero.repository.MissionRepository.MissionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
@@ -26,6 +27,12 @@ public class MissionQueryServiceImpl implements MissionQueryService{
         Pageable pageable = PageRequest.of(page, 10, Sort.by("createdAt").descending());
         Page<Mission> missions = missionRepository.findChallengingMissionsByMemberId(memberId, pageable);
         return missionConverter.toChallengingMissionResponseList(missions.getContent());
+    }
 
+    @Override
+    public List<StoreMissionResponse> getMissionsByStoreId(Long storeId, int page) {
+        Pageable pageable = PageRequest.of(page, 10, Sort.by("createdAt").descending());
+        Page<Mission> missions = missionRepository.findByStore_StoreId(storeId, pageable);
+        return missionConverter.toStoreMissionResponseList(missions.getContent());
     }
 }


### PR DESCRIPTION
<!----제목은 [type/#IssueNumber] 작업 내용 -->
<!----ex) [setting/#1] 디자인 시스템 폰트 정의 -->

## **♻️ ISSUE**

- closed #10 

## **❗ WORK DESCRIPTION**

- 특정 가게의 미션 목록 조회 API

## **📸 SCREENSHOT**

<!---- <video src="" width="300" /> -->
<!---- <img src="" width="300" /> -->
<!----Before | After
  :--: | :--:
  <img src="" width="300" /> | <img src="" width="300" >-->

## **💻 주요 코드**

- 특정 가게의 미션 목록 조회 API
- 아래 조건 충족
  - [ ]  Paging 처리, 한 페이지에 10개씩 조회, 프론트엔드에서는 1 이상의 page 번호 전달
  - [ ] 프론트엔드가 주는 page를 쿼리 스트링으로 받아오고, 이에 대해 처리하는 커스텀 어노테이션 구현
  - [ ] 커스텀 어노테이션은 page 1을 0으로 만들어 리턴
  - [ ] page 범위 0 이하는 에러 발생시키기
  - [ ] 에러 발생시 RestControllerAdvice 연계
  - [ ] swagger 명세
  - [ ] converter에서 Java Stream 이용
  - [ ] 빌더 패턴  이용
  - [ ] CQRS 패턴 이용

## **📢 TO REVIEWERS**

- 리뷰어에게 전달해야 하는 말